### PR TITLE
fix: harden kinetic fallback and eddy coupling after #79

### DIFF
--- a/test/test_eddy_impedance.py
+++ b/test/test_eddy_impedance.py
@@ -1,24 +1,28 @@
 import numpy as np
-from omas import ODS
+from omas import ODS, load_omas_json
 
+from vaft.data.resources import data_path
+from vaft.machine_mapping.pf_active import vfit_pf_active_static
 from vaft.omas.process_wrapper import compute_impedance_matrices_ods
-from vaft.process import compute_impedance_matrices
+from vaft.process import (
+    compute_impedance_matrices,
+    compute_mutual_passive_active,
+)
 
 
-def test_impedance_uses_em_coupling_for_standard_matrix_blocks():
+def test_impedance_uses_em_coupling_when_geometry_is_not_provided():
     loop_resistances = np.array([2.0, 3.0])
     passive_loop_geometry = [
         ("W11", 0.3, 0.1, 1.0),
         ("W12", 0.4, -0.1, 1.04),
     ]
-    coil_geometry = [[(9.0, 9.0, 999)]]
     mutual_pp = np.array([[10.0, 1.0], [1.0, 20.0]])
     mutual_pa = np.array([[0.4], [0.5]])
 
     R_mat, L_mat, M_mat = compute_impedance_matrices(
         loop_resistances,
         passive_loop_geometry,
-        coil_geometry,
+        None,
         mutual_pp,
         mutual_pa,
         [(0.35, 0.0)],
@@ -30,9 +34,73 @@ def test_impedance_uses_em_coupling_for_standard_matrix_blocks():
     assert L_mat.shape == (2, 2)
 
 
+def test_impedance_uses_current_geometry_when_reference_coupling_differs():
+    reference = load_omas_json(
+        str(data_path("omas/39915.json")),
+        consistency_check=False,
+    )
+    passive_geometry = []
+    for index in range(5):
+        loop = reference[f"pf_passive.loop.{index}"]
+        if loop["element.0.geometry.geometry_type"] == 1:
+            r = np.mean(loop["element.0.geometry.outline.r"])
+            z = np.mean(loop["element.0.geometry.outline.z"])
+        else:
+            r = loop["element.0.geometry.rectangle.r"]
+            z = loop["element.0.geometry.rectangle.z"]
+        passive_geometry.append(
+            (
+                loop["name"],
+                r,
+                z,
+                1.0 if loop["name"] == "W11" else 1.04,
+            )
+        )
+
+    current = ODS(consistency_check=False)
+    vfit_pf_active_static(current, shot=48223)
+    pf6_geometry = [
+        [
+            (
+                current[
+                    f"pf_active.coil.5.element.{index}.geometry.rectangle.r"
+                ],
+                current[
+                    f"pf_active.coil.5.element.{index}.geometry.rectangle.z"
+                ],
+                current[
+                    f"pf_active.coil.5.element.{index}.turns_with_sign"
+                ],
+            )
+            for index in range(len(current["pf_active.coil.5.element"]))
+        ]
+    ]
+    reference_coupling = np.asarray(
+        reference["em_coupling.mutual_passive_active"],
+    )[:5, 5:6]
+    expected = compute_mutual_passive_active(
+        passive_geometry,
+        pf6_geometry,
+    )
+    assert not np.allclose(expected, reference_coupling, rtol=1e-3, atol=1e-12)
+
+    _, L_mat, _ = compute_impedance_matrices(
+        np.ones(5),
+        passive_geometry,
+        pf6_geometry,
+        np.eye(5),
+        reference_coupling,
+        [],
+    )
+    np.testing.assert_allclose(L_mat, expected)
+
+
 def test_impedance_wrapper_does_not_write_non_imas_cache_locations():
     ods = ODS(consistency_check=False)
     ods["pf_active.coil.0.name"] = "PF1"
+    ods["pf_active.coil.0.element.0.geometry.rectangle.r"] = 0.5
+    ods["pf_active.coil.0.element.0.geometry.rectangle.z"] = 0.2
+    ods["pf_active.coil.0.element.0.turns_with_sign"] = 10
 
     for index, (name, resistance, r, z) in enumerate(
         [("W11", 2.0, 0.3, 0.1), ("W12", 3.0, 0.4, -0.1)]
@@ -50,7 +118,15 @@ def test_impedance_wrapper_does_not_write_non_imas_cache_locations():
         ] = z
 
     mutual_pp = np.array([[10.0, 1.0], [1.0, 20.0]])
-    mutual_pa = np.array([[0.4], [0.5]])
+    passive_geometry = [
+        ("W11", 0.3, 0.1, 1.0),
+        ("W12", 0.4, -0.1, 1.04),
+    ]
+    coil_geometry = [[(0.5, 0.2, 10)]]
+    mutual_pa = compute_mutual_passive_active(
+        passive_geometry,
+        coil_geometry,
+    )
     ods["em_coupling.mutual_passive_passive"] = mutual_pp
     ods["em_coupling.mutual_passive_active"] = mutual_pa
 

--- a/test/test_ti_te_ratio.py
+++ b/test/test_ti_te_ratio.py
@@ -141,6 +141,20 @@ def test_core_profiles_ratio_ignored_with_real_ion_fit():
     )
 
 
+@pytest.mark.parametrize("ratio", [-0.1, np.nan, np.inf])
+def test_core_profiles_rejects_invalid_ratio(ratio):
+    ods, psi_n_ch = _make_ts_only_ods()
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        core_profiles(
+            ods,
+            300.0,
+            psi_n_ch,
+            _ne,
+            _te,
+            ti_te_ratio=ratio,
+        )
+
+
 # --------------------------------------------------------------------------- #
 # kineticEfit: Thomson-only pressure points (statistical fallback)
 # --------------------------------------------------------------------------- #
@@ -235,6 +249,36 @@ def test_ts_only_custom_ratio_and_sigma():
 def test_ts_only_bad_ratio_string_rejected():
     with pytest.raises(ValueError):
         km._resolve_ti_te_ratio("bogus")
+
+
+@pytest.mark.parametrize(
+    "ratio,sigma",
+    [
+        (-0.1, 0.1),
+        (np.nan, 0.1),
+        (np.inf, 0.1),
+        (0.2, -0.1),
+        (0.2, np.nan),
+    ],
+)
+def test_ts_only_invalid_ratio_or_sigma_rejected(ratio, sigma):
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        km._resolve_ti_te_ratio(ratio, sigma)
+
+
+def test_ts_only_invalid_uncertainties_use_finite_fallbacks():
+    ods = _make_ts_only_raw_ods()
+    ods["thomson_scattering"]["channel"][0]["n_e"]["data_error_upper"][1] = np.nan
+    ods["thomson_scattering"]["channel"][0]["t_e"]["data_error_upper"][1] = 0.0
+
+    R, ne, Te, sne, sTe, *_ = km._raw_ne_te_ti(ods, 300.0, None)
+    assert R.size == 2
+    assert sne[0] == pytest.approx(0.1 * ne[0])
+    assert sTe[0] == pytest.approx(0.1 * Te[0])
+
+    points = km.kinetic_pressure_points(ods, 300.0, None, encoding="raw5")
+    assert np.all(np.isfinite(points.sigpre))
+    assert np.all(np.asarray(points.sigpre) > 0.0)
 
 
 def test_fallback_not_used_when_ion_data_present():

--- a/vaft/code/kineticEfit.py
+++ b/vaft/code/kineticEfit.py
@@ -111,6 +111,12 @@ def _resolve_ti_te_ratio(ti_te_ratio, ti_te_ratio_sigma=None):
         if ti_te_ratio_sigma is None
         else float(ti_te_ratio_sigma)
     )
+    if not np.isfinite(ratio) or ratio < 0.0:
+        raise ValueError(f"ti_te_ratio must be finite and non-negative, got {ratio!r}")
+    if not np.isfinite(sigma) or sigma < 0.0:
+        raise ValueError(
+            f"ti_te_ratio_sigma must be finite and non-negative, got {sigma!r}"
+        )
     return ratio, sigma
 
 
@@ -397,6 +403,10 @@ def _raw_ne_te_ti(
     if not np.any(ts_valid):
         raise RuntimeError(f"no valid Thomson channels in ODS at {time_ms} ms")
     R, ne, Te, sne, sTe = R[ts_valid], ne[ts_valid], Te[ts_valid], sne[ts_valid], sTe[ts_valid]
+    # Preserve otherwise valid channels whose uncertainty is absent or invalid,
+    # but assign a conservative 10% fallback so EFIT never receives SIGPRE=NaN.
+    sne = np.where(np.isfinite(sne) & (sne > 0.0), sne, 0.1 * np.abs(ne))
+    sTe = np.where(np.isfinite(sTe) & (sTe > 0.0), sTe, 0.1 * np.abs(Te))
 
     # --- Charge exchange Ti (nearest time per channel); statistical Ti = ratio*Te
     #     fallback when the shot has no usable ion data (Thomson-only) ---

--- a/vaft/omas/process_wrapper.py
+++ b/vaft/omas/process_wrapper.py
@@ -337,11 +337,33 @@ def compute_impedance_matrices_ods(
             coef = 1.0 if loop_name == "W11" else 1.04
             passive_loop_geometry.append((loop_name, r_avg, z_avg, coef))
 
+        # Extract the current shot's active-coil geometry. The packaged
+        # em_coupling matrix represents the historical configuration, while
+        # newer shots can use a different PF6/PF7 geometry.
+        coil_geometry = []
+        for i_coil in range(nbcoil):
+            elements = []
+            for i_element in range(len(pf[f"coil.{i_coil}.element"])):
+                elements.append(
+                    (
+                        pf[
+                            f"coil.{i_coil}.element.{i_element}.geometry.rectangle.r"
+                        ],
+                        pf[
+                            f"coil.{i_coil}.element.{i_element}.geometry.rectangle.z"
+                        ],
+                        pf[
+                            f"coil.{i_coil}.element.{i_element}.turns_with_sign"
+                        ],
+                    )
+                )
+            coil_geometry.append(elements)
+
         # Compute impedance matrices
         R_mat, L_mat, M_mat = compute_impedance_matrices(
             loop_res,
             passive_loop_geometry,
-            None,
+            coil_geometry,
             mutual_pp,
             mutual_pa,
             plasma

--- a/vaft/process/electromagnetics.py
+++ b/vaft/process/electromagnetics.py
@@ -243,6 +243,35 @@ def compute_response_vector(
         plasma_points=plasma_points
     )
 
+def compute_mutual_passive_active(
+    passive_loop_geometry: List[Tuple[str, float, float, float]],
+    coil_geometry: List[List[Tuple[float, float, int]]],
+) -> np.ndarray:
+    """Compute passive-to-active mutual inductance from the current geometry.
+
+    The packaged ``em_coupling.mutual_passive_active`` matrix represents the
+    historical VEST coil geometry.  Newer shots can use a different active-coil
+    geometry, so callers need a geometry-derived fallback when the packaged
+    matrix is not compatible.
+    """
+    coupling = np.zeros((len(passive_loop_geometry), len(coil_geometry)))
+
+    for i_loop, (_, r_loop, z_loop, coefficient) in enumerate(
+        passive_loop_geometry
+    ):
+        for i_coil, elements in enumerate(coil_geometry):
+            if not elements:
+                raise ValueError(f"active coil {i_coil} has no geometry elements")
+            total_turns = sum(element[2] for element in elements)
+            mean_response = sum(
+                green_r(r_loop, z_loop, r_coil, z_coil)
+                for r_coil, z_coil, _ in elements
+            ) / len(elements)
+            coupling[i_loop, i_coil] = coefficient * total_turns * mean_response
+
+    return coupling
+
+
 def compute_impedance_matrices(
     loop_resistances: np.ndarray,
     passive_loop_geometry: List[Tuple[str, float, float, float]],  
@@ -262,8 +291,9 @@ def compute_impedance_matrices(
            - average_r (float),
            - average_z (float),
            - geometry_coef (float)  # e.g. 1.0 or 1.04 ...
-    :param coil_geometry: retained for API compatibility. Active-coil coupling
-        is read from ``mutual_pa`` rather than recomputed from this geometry.
+    :param coil_geometry: active-coil geometry. When provided, its coupling is
+        compared with ``mutual_pa`` and used if the packaged matrix represents
+        a different geometry. ``None`` requires and uses ``mutual_pa`` directly.
     :param mutual_pp: mutual_passive_passive matrix from external (shape = (nbloop, nbloop)).
     :param mutual_pa: mutual_passive_active matrix from external (shape = (nbloop, nbcoil)).
     :param plasma_rz: list of (r, z) for each plasma current element (optional).
@@ -302,11 +332,28 @@ def compute_impedance_matrices(
     # M is the standard passive-to-passive coupling from em_coupling.
     M_mat = mutual_pp
 
-    # The active-coil portion of L is the standard passive-to-active coupling
-    # from em_coupling. Plasma filaments are transient VAFT solver inputs; until
-    # they are represented by pf_plasma.element URIs, compute only that portion.
+    active_coupling = mutual_pa
+    if coil_geometry is not None:
+        geometry_coupling = compute_mutual_passive_active(
+            passive_loop_geometry,
+            coil_geometry,
+        )
+        # The packaged reference agrees with the historical geometry to
+        # floating-point precision. Newer VEST geometries (notably PF6/PF7 in
+        # the 2507 configuration) differ materially and must use the geometry
+        # calculation until versioned em_coupling matrices are available.
+        if not np.allclose(
+            geometry_coupling,
+            mutual_pa,
+            rtol=1e-10,
+            atol=1e-15,
+        ):
+            active_coupling = geometry_coupling
+
+    # Plasma filaments are transient VAFT solver inputs; until they are
+    # represented by pf_plasma.element URIs, compute only that portion here.
     if nbplas == 0:
-        L_mat = mutual_pa
+        L_mat = active_coupling
     else:
         plasma_coupling = np.zeros((nbloop, nbplas))
         for i_loop, (loop_name, r1, z1, coef) in enumerate(passive_loop_geometry):
@@ -314,7 +361,7 @@ def compute_impedance_matrices(
                 plasma_coupling[i_loop, j_plasma] = (
                     coef * green_r(r1, z1, rp, zp)
                 )
-        L_mat = np.hstack((mutual_pa, plasma_coupling))
+        L_mat = np.hstack((active_coupling, plasma_coupling))
 
     return R_mat, L_mat, M_mat
 

--- a/vaft/process/profile.py
+++ b/vaft/process/profile.py
@@ -920,11 +920,17 @@ def core_profiles(
         T_i_recon = np.asarray(T_i_function(psi_n_grid), dtype=float)
     elif have_e and ti_te_fallback:
         if ti_te_ratio is not None:
-            T_i_recon = float(ti_te_ratio) * T_e_recon
+            ratio = float(ti_te_ratio)
+            if not np.isfinite(ratio) or ratio < 0.0:
+                raise ValueError(
+                    "ti_te_ratio must be finite and non-negative, "
+                    f"got {ratio!r}"
+                )
+            T_i_recon = ratio * T_e_recon
             ratio_fallback = True
             print(
                 f"[INFO] no ion fit at {time_ms:.3f} ms: statistical fallback "
-                f"Ti = {float(ti_te_ratio):.3f}*Te (kinetic pressure written)"
+                f"Ti = {ratio:.3f}*Te (kinetic pressure written)"
             )
         else:
             T_i_recon = T_e_recon

--- a/workflow/automatic_pipeline_2_corrective_data_update/update_thomson_scattering_and_core_profile.py
+++ b/workflow/automatic_pipeline_2_corrective_data_update/update_thomson_scattering_and_core_profile.py
@@ -320,6 +320,7 @@ def main():
 
 
                     chease_dir = os.path.join(PUBLIC_BASE, f"{shotnumber}/chease")
+                    fitted = False
                     if os.path.exists(chease_dir):
                         try:
                             fitted = fit_thomson_profile_auto_all_times(ods, shotnumber)


### PR DESCRIPTION
## Summary

Follow-up fixes from the final review of #79:

- derive passive/active coupling from the current shot's PF geometry when the packaged `em_coupling` matrix represents a different configuration (notably PF6/PF7 after the 1906→2507 geometry change)
- retain canonical `em_coupling` matrices when they agree with the current geometry
- replace missing, non-finite, or non-positive Thomson uncertainties with finite 10% fallbacks before kinetic-EFIT pressure construction
- reject negative/non-finite Ti/Te ratios and ratio uncertainties in both entry paths
- initialize the corrective watcher fit state so missing CHEASE data or a fit exception cannot reuse or reference an undefined result
- retain direct regression coverage for schema-safe eddy output and the current-geometry coupling path

The `develop` version of `notebooks/verify_exist_shot_and_load.ipynb` is intentionally unchanged.

## Verification

- `python -m pytest -q test/test_eddy_impedance.py test/test_ti_te_ratio.py` — 24 passed
- `python -m pytest -q` — 319 passed, 5 skipped
- `git diff --check`

## Deferred follow-ups

- #81 — version `em_coupling` by PF geometry and populate coupling coordinates
- #82 — optimize `combine_ods` invalid-location filtering for large legacy artifacts
- #42 — implement `pf_plasma`; expanded with plasma/passive coupling acceptance criteria

Follow-up to #79.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eddy-current L-matrix coupling for newer coil geometries and alters kinetic-EFIT pressure uncertainty handling; both affect reconstruction stability but are guarded by validation and regression tests.
> 
> **Overview**
> Follow-up hardening after #79: **eddy impedance** now derives passive–active mutual inductance from the shot’s PF coil geometry when it disagrees with packaged `em_coupling` (e.g. PF6/PF7 after 1906→2507), while still using the canonical matrix when geometry matches.
> 
> **Kinetic / core profiles** reject non-finite or negative `ti_te_ratio` and sigma on both `kineticEfit` and `core_profiles` paths; Thomson channels with missing or invalid `ne`/`Te` uncertainties get a **10% fallback** so EFIT pressure constraints never see `SIGPRE=NaN`.
> 
> The corrective Thomson watcher initializes **`fitted = False`** before CHEASE/fit logic so a missing directory or exception cannot leave an undefined fit flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c069808be57a5b19ecd04c8afdc64739db2dac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->